### PR TITLE
Fix findById method in TransactionRepository

### DIFF
--- a/src/repository/TransactionRepository.ts
+++ b/src/repository/TransactionRepository.ts
@@ -78,8 +78,15 @@ export class TransactionRepository {
   }
 
   async findById(ids: string[]): Promise<Transaction[]> {
-    return await this.ctx.store.findBy(Transaction, {
-      id: In([...ids]),
+    let tx = await this.ctx.store.find(Transaction, {
+      relations: {
+        multisig: true,
+      },
+      where: {
+        id: In([...ids]),
+      },
     });
+
+    return tx;
   }
 }


### PR DESCRIPTION
- Processor crashed when executing fetchTransactionDataFromDBIfNeeded

> Error dump:
```
processor_1  | {"level":5,"time":1707758170814,"ns":"sqd:processor","err":{"stack":"TypeError: Cannot read properties of undefined (reading 'addressHex')\n    at MultisigEventHandler.fetchTransactionDataFromDBIfNeeded (/squid/lib/mappings/MultisigEventHandler.js:153:41)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at async MultisigEventHandler.handleApprove (/squid/lib/mappings/MultisigEventHandler.js:126:9)\n    at async MultisigEventHandler.handleEvent (/squid/lib/mappings/MultisigEventHandler.js:61:17)\n    at async /squid/lib/main.js:62:21\n    at async TypeormDatabase.performUpdates (/squid/node_modules/@subsquid/typeorm-store/lib/database.js:139:13)\n    at async /squid/node_modules/@subsquid/typeorm-store/lib/database.js:84:13\n    at async EntityManager.transaction (/squid/node_modules/typeorm/entity-manager/EntityManager.js:73:28)\n    at async TypeormDatabase.submit (/squid/node_modules/@subsquid/typeorm-store/lib/database.js:151:24)\n    at async Runner.withProgressMetrics (/squid/node_modules/@subsquid/util-internal-processor-tools/lib/runner.js:183:22)"}}
```

Fixed by adding explicit dependency with multisig entity